### PR TITLE
Image compression and downscaling; remove background added

### DIFF
--- a/WebContent/core/manifest.json
+++ b/WebContent/core/manifest.json
@@ -4,7 +4,7 @@
     "16": "resources/icon_16.png",
     "48": "resources/icon_48.png",
     "128": "resources/icon_128.png" },
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Page processor used by SingleFile",
   "background": {
     "scripts": [

--- a/WebContent/core/scripts/bg/bgcore.js
+++ b/WebContent/core/scripts/bg/bgcore.js
@@ -22,7 +22,7 @@
 
 	singlefile.PageData = PageData;
 	singlefile.DocData = DocData;
-
+	//4. Called from core/scripts/bg/background.js coreProcess
 	function PageData(tabId, pageId, senderId, config, processSelection, processFrame, callback) {
 		var timeoutError, that = this;
 		this.pageId = pageId;
@@ -53,10 +53,10 @@
 				tabId : tabId
 			});
 		}, 15000);
-		wininfo.init(tabId, function(processableDocs) {
+		wininfo.init(tabId, function(processableDocs) { //follow action to core/scripts/bg/wininfo.js
 			clearTimeout(timeoutError);
 			that.processableDocs = processableDocs;
-			callback();
+			callback(); //10. follow action to core/scripts/bg/background.js coreProcess
 		});
 	}
 
@@ -70,7 +70,7 @@
 				} else
 					docData.process();
 			});
-		},
+		}, //16.
 		processDoc : function(port, topWindow, winId, index, content, title, url, baseURI, characterSet, canvasData, contextmenuTime, callbacks) {
 			var that = this, docData;
 			docData = new DocData(port, winId, index, content, baseURI, characterSet, canvasData);
@@ -93,7 +93,7 @@
 							callbacks.progress(that, docData, index);
 						}, function() {
 							callbacks.end(that, docData);
-						});
+						}); //follow action to core/scripts/common/docprocessor.js initProcess
 			}
 		},
 		processDocFragment : function(docData, mutationEventId, content) {
@@ -106,7 +106,7 @@
 						docData.setDocFragment(doc.body.innerHTML, mutationEventId);
 					});
 		},
-		setDocContent : function(docData, content, callback) {
+		setDocContent : function(docData, content, callback) { //21. Called from core/scripts/bg/background.js docEnd; callback is setContentResponse
 			var selectedDocData, that = this;
 
 			function buildPage(docData, setFrameContent, getContent, callback) {
@@ -199,10 +199,10 @@
 				that.progressMax += docData.progressMax || 0;
 			});
 		},
-		getResourceContentRequest : function(url, requestId, winId, characterSet, mediaTypeParam, docData) {
+		getResourceContentRequest : function(url, requestId, winId, characterSet, mediaTypeParam, docData, node, scale) {
 			this.requestManager.send(url, function(content) {
 				docData.getResourceContentResponse(content, requestId);
-			}, characterSet, mediaTypeParam);
+			}, characterSet, mediaTypeParam, node, scale);
 		},
 		getDocData : function(winId) {
 			var found;
@@ -235,9 +235,7 @@
 	DocData.prototype = {
 		parseContent : function() {
 			var doc = document.implementation.createHTMLDocument();
-			doc.open();
-			doc.write(this.content);
-			doc.close();
+			doc.documentElement.innerHTML = this.content; //this also works in firefox. doc.write works only if added to document
 			this.doc = doc;
 			this.docFrames = doc.querySelectorAll("iframe, frame");
 			delete this.content;

--- a/WebContent/core/scripts/bg/nio.js
+++ b/WebContent/core/scripts/bg/nio.js
@@ -70,11 +70,11 @@
 				xhr = new XMLHttpRequest();
 				xhr.onload = function() {
 					clearTimeout(timeout);
-					var media = xhr.getResponseHeader("Content-Type");
+					var media = xhr.getResponseHeader("Content-Type") || xhr.getResponseHeader("content-type");
 					var data = mediaTypeParam == "base64" ? arrayBufferToBase64(xhr.response) : xhr.responseText;
 			        	
-					if (media.indexOf('image') >= 0 && media.indexOf('svg') < 0 && 
-						mediaTypeParam == "base64" && (scale < 1 || node && (node.width || node.height))) {
+					if (media && media.indexOf('image') >= 0 && media.indexOf('svg') < 0 && 
+						mediaTypeParam == "base64" && scale > 0 && (scale < 1 || node && (node.width || node.height))) {
 							var img = new Image();
 							// When the event "onload" is triggered we can resize the image.
 					        img.onload = function()

--- a/WebContent/core/scripts/bg/nio.js
+++ b/WebContent/core/scripts/bg/nio.js
@@ -52,7 +52,7 @@
 			keys = [];
 		};
 
-		this.send = function(url, responseHandler, characterSet, mediaTypeParam) {
+		this.send = function(url, responseHandler, characterSet, mediaTypeParam, node, scale) {
 			var xhr, timeout, key = JSON.stringify({
 				url : url,
 				characterSet : characterSet,
@@ -70,15 +70,97 @@
 				xhr = new XMLHttpRequest();
 				xhr.onload = function() {
 					clearTimeout(timeout);
-					cache[key] = {
-						url : url,
-						status : xhr.status,
-						mediaType : xhr.getResponseHeader("Content-Type"),
-						content : mediaTypeParam == "base64" ? arrayBufferToBase64(xhr.response) : xhr.responseText,
-						mediaTypeParam : mediaTypeParam
-					};
-					keys.push(key);
-					sendResponses(key);
+					var media = xhr.getResponseHeader("Content-Type");
+					var data = mediaTypeParam == "base64" ? arrayBufferToBase64(xhr.response) : xhr.responseText;
+			        	
+					if (media.indexOf('image') >= 0 && media.indexOf('svg') < 0 && 
+						mediaTypeParam == "base64" && (scale < 1 || node && (node.width || node.height))) {
+							var img = new Image();
+							// When the event "onload" is triggered we can resize the image.
+					        img.onload = function()
+				            {        
+				            	clearTimeout(timeout);
+				            	var ratio = Math.min(1, node && node.width ? node.width / img.width : 1,
+			            			node && node.height ? node.height / img.height : 1);
+		            			if (ratio < 1 || media.indexOf('jp') < 0 || scale < 1) {
+					                 // We create a canvas and get its context.
+					                var canvas = document.createElement('canvas');
+					                var ctx = canvas.getContext('2d');
+					
+					                // We set the dimensions at the wanted size.
+					                canvas.width = img.width * ratio;
+					                canvas.height = img.height * ratio;
+					
+					                // We resize the image with the canvas method drawImage();
+					                ctx.drawImage(this, 0, 0, canvas.width, canvas.height);
+					                
+					                //Determine whether it contains transparent pixels
+					                var transparent = false;
+					                if (media.indexOf('png') > 0) {
+					                  var imgData=ctx.getImageData(0,0,canvas.width,canvas.height);
+									  var dat=imgData.data;
+									  var n = dat.length;
+									  for(var i=0;i< n && !transparent;i+=4){
+									    if(dat[i+3]<255){ transparent = true; }
+									  }
+					                }
+									//Decide on the output format
+									if (ratio < 1 && transparent) {
+										var dp = canvas.toDataURL(media).replace(/data:image.+;base64,/, '');
+										if (dp.length < data.length)
+											data = dp;
+									} else if (media.indexOf('jp') > 0) {
+										if (ratio < 1 || scale < 1) {
+											var ds = canvas.toDataURL('image/jpeg', scale)
+												.replace(/data:image.+;base64,/, '');
+											if (ds.length < data.length) {
+												data = ds;
+												media = 'image/jpeg';
+											}
+										}
+									} else if (!transparent && (media.indexOf('png') < 0 || scale < 1)) {
+										var d = canvas.toDataURL('image/png')
+											.replace(/data:image.+;base64,/, '');
+										var d2 = canvas.toDataURL('image/jpeg', scale)
+											.replace(/data:image.+;base64,/, '');
+										var min = Math.min(d.length, d2.length, data.length);
+										if (min === data.length);
+										else if (min === d.length) {
+											data = d;
+											media = 'image/png';
+										} else {
+											data = d2;
+											media = 'image/jpeg';
+										}
+									}
+		            			}
+								cache[key] = {
+									url : url,
+									status : xhr.status,
+									mediaType : media,
+									content : data,
+									mediaTypeParam : mediaTypeParam
+								};
+								keys.push(key);
+								sendResponses(key);
+				            };
+					        img.onerror = function() {
+								cache[key] = {};
+								keys.push(key);
+								sendResponses(key);
+							};   
+					        img.src = "data:" + media + ";base64," + data;
+					} else {
+						cache[key] = {
+							url : url,
+							status : xhr.status,
+							mediaType : media,
+							content : data,
+							mediaTypeParam : mediaTypeParam
+						};
+						keys.push(key);
+						sendResponses(key);
+					}
 				};
 				xhr.onerror = function() {
 					cache[key] = {};

--- a/WebContent/core/scripts/bg/wininfo.js
+++ b/WebContent/core/scripts/bg/wininfo.js
@@ -20,10 +20,12 @@
 
 var wininfo = { //5. Called from core/scripts/bg/bgcore.js PageData
 	init : function(tabId, callback) {
-		chrome.extension.onMessage.addListener(function(message) {
+		chrome.extension.onMessage.addListener(function lid(message) {
 			// console.log("wininfo.onMessage", tabId, message);
-			if (message.initResponse) //9. Called from core/scripts/content/wininfo.js initResponse
-				callback(message.processableDocs); //follow action to core/scripts/bg/bgcore.js PageData
+		    if (message.initResponse) { //9. Called from core/scripts/content/wininfo.js initResponse
+		        callback(message.processableDocs); //follow action to core/scripts/bg/bgcore.js PageData
+		        chrome.extension.onMessage.removeListener(lid);
+		    }
 		});
 		chrome.tabs.sendMessage(tabId, { //follow action to core/scripts/content/wininfo.js onExtensionMessage
 			initRequest : true,

--- a/WebContent/core/scripts/bg/wininfo.js
+++ b/WebContent/core/scripts/bg/wininfo.js
@@ -18,14 +18,14 @@
  *   along with SingleFile Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var wininfo = {
+var wininfo = { //5. Called from core/scripts/bg/bgcore.js PageData
 	init : function(tabId, callback) {
 		chrome.extension.onMessage.addListener(function(message) {
 			// console.log("wininfo.onMessage", tabId, message);
-			if (message.initResponse)
-				callback(message.processableDocs);
+			if (message.initResponse) //9. Called from core/scripts/content/wininfo.js initResponse
+				callback(message.processableDocs); //follow action to core/scripts/bg/bgcore.js PageData
 		});
-		chrome.tabs.sendMessage(tabId, {
+		chrome.tabs.sendMessage(tabId, { //follow action to core/scripts/content/wininfo.js onExtensionMessage
 			initRequest : true,
 			winId : "0",
 			index : 0

--- a/WebContent/core/scripts/content/content.js
+++ b/WebContent/core/scripts/content/content.js
@@ -25,7 +25,7 @@
 	function RequestManager(pageId, winId) {
 		var requestId = 0, callbacks = [];
 
-		this.send = function(url, responseHandler, characterSet, mediaTypeParam) {
+		this.send = function(url, responseHandler, characterSet, mediaTypeParam, node, scale) {
 			callbacks[requestId] = responseHandler;
 			bgPort.postMessage({
 				getResourceContentRequest : true,
@@ -34,7 +34,9 @@
 				requestId : requestId,
 				url : url,
 				characterSet : characterSet,
-				mediaTypeParam : mediaTypeParam
+				mediaTypeParam : mediaTypeParam,
+				node : node,
+				scale : scale
 			});
 			requestId++;
 		};
@@ -172,13 +174,13 @@
 			index : winIndex || wininfo.index
 		});
 	}
-
+	//14.
 	function sendBgProcessInit(content, title, url, baseURI, characterSet, winId, winIndex) {
 		var contextmenuTime = window.contextmenuTime;
 		if (!this.wininfo)
 			return;
 		window.contextmenuTime = null;
-		bgPort.postMessage({
+		bgPort.postMessage({ //follow action to core/scripts/bg/background.js processInit
 			processInit : true,
 			pageId : pageId,
 			topWindow : winId ? false : window == top,
@@ -195,7 +197,7 @@
 	}
 
 	// ----------------------------------------------------------------------------------------------
-
+	//12. Called from core/scripts/bg/background.js coreProcess
 	function init() {
 		var selectedContent = getSelectedContent(), topWindow = window == top;
 
@@ -217,7 +219,7 @@
 					});
 			}
 		}
-
+		//13.
 		function bgProcessInit() {
 			var xhr;
 			if (singlefile.processSelection) {

--- a/WebContent/core/scripts/content/wininfo.js
+++ b/WebContent/core/scripts/content/wininfo.js
@@ -141,7 +141,7 @@ var wininfo = {};
 		delete message.getContentResponse;
 		contentRequestCallbacks[id](message);		
 	}
-
+	//7.
 	function initRequest(message) {
 		wininfo.winId = message.winId;
 		wininfo.index = message.index;
@@ -155,7 +155,7 @@ var wininfo = {};
 		}, 3000);
 		location.href = "javascript:(" + executeSetFramesWinIdString + ")('" + EXT_ID + "'," + wininfo.index + ",'" + wininfo.winId + "'); void 0;";
 	}
-
+	//8.
 	function initResponse(message) {
 		function process() {
 			wininfo.frames = wininfo.frames.filter(function(frame) {
@@ -192,7 +192,7 @@ var wininfo = {};
 			wininfo.index = message.index;
 		}
 	}
-
+	//6. Called from core/scripts/bg/wininfo.js
 	function onExtensionMessage(message) {
 		if (message.initRequest && document.documentElement instanceof HTMLHtmlElement) {
 			contentRequestCallbacks = [];

--- a/WebContent/ui/manifest.json
+++ b/WebContent/ui/manifest.json
@@ -4,7 +4,7 @@
     "16": "resources/icon_16.png",
     "48": "resources/icon_48.png",
     "128": "resources/icon_128.png" },
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Archive a complete page into a single HTML file",
   "background" : {
     "scripts": [

--- a/WebContent/ui/pages/options.html
+++ b/WebContent/ui/pages/options.html
@@ -33,6 +33,15 @@
 		</div>
 	</div>
 	<div class="option">
+		<label for="removeBackgroundImages">remove background images <img class="question-mark" src="../resources/icon_question_mark.jpg">
+		</label>
+		<input type="checkbox" id="removeBackgroundImages">
+		<div class="help">
+			<p>Check this option to remove all background images.</p>
+			<p class="notice">It is recommended to <u>uncheck</u> this option</p>
+		</div>
+	</div>
+	<div class="option">
 		<label for="displayInContextMenuInput">add entry in the context menu <img class="question-mark" src="../resources/icon_question_mark.jpg"></label> <input type="checkbox" id="displayInContextMenuInput">
 		<div class="help">
 			<p>Check this option to launch processing on a page with context menu.</p>
@@ -44,6 +53,15 @@
 		<div class="help">
 			<p>Check this option to display a banner with a download link at the top of the page when processing is finished.</p>
 			<p class="notice">It is recommended to <u>check</u> this option</p>
+		</div>
+	</div>
+	<div class="option">
+		<label for="scaleImages">scale down and compress images <img class="question-mark" src="../resources/icon_question_mark.jpg">
+		</label>
+		<input type="number" id="scaleImages" min="0" max="1" step="0.1">
+		<div class="help">
+			<p>Use this option to scale down images to the size they are displayed in and compress them to the quality chosen. This can make the output file smaller. 0 means 'off'</p>
+			<p class="notice">It is recommended to set this option <u>0.2</u> </p>
 		</div>
 	</div>
 	<h4>Advanced options</h4>

--- a/WebContent/ui/scripts/bg/background.js
+++ b/WebContent/ui/scripts/bg/background.js
@@ -56,7 +56,7 @@
 			if (detected) {
 				if (processable(url)) {
 					singlefile.ui.notifyProcessInit(tabId);
-					chrome.extension.sendMessage(SINGLE_FILE_CORE_EXT_ID, {
+					chrome.extension.sendMessage(SINGLE_FILE_CORE_EXT_ID, { //in core/scripts/bg/background.js
 						processSelection : processSelection,
 						processFrame : processFrame,
 						id : tabId,

--- a/WebContent/ui/scripts/bg/config.js
+++ b/WebContent/ui/scripts/bg/config.js
@@ -40,7 +40,9 @@
 			getRawDoc : false,
 			displayInContextMenu : true,
 			sendToPageArchiver : false,
-			displayBanner : true
+			displayBanner : true,
+			scaleImages : 0.2,
+			removeBackgroundImages : false
 		};
 	};
 
@@ -65,6 +67,16 @@
 		var conf = singlefile.config.get();
 		if (typeof conf.maxFrameSize == "undefined") {
 			conf.maxFrameSize = 2;
+			singlefile.config.set(conf);
+		}
+	}
+
+	// migration 0.3.18 -> 0.3.19
+	if (localStorage.config) {
+		var conf = singlefile.config.get();
+		if (typeof conf.scaleImages == "undefined") {
+			conf.scaleImages = 0.2;
+			conf.removeBackgroundImages = false;
 			singlefile.config.set(conf);
 		}
 	}

--- a/WebContent/ui/scripts/bg/options.js
+++ b/WebContent/ui/scripts/bg/options.js
@@ -19,8 +19,10 @@
  */
 (function() {
 
-	var removeScriptsInput, removeFramesInput, removeObjectsInput, removeHiddenInput, removeUnusedCSSRulesInput, processInBackgroundInput, maxFrameSizeInput, getRawDocInput, sendToPageArchiverInput, displayBannerInput, displayInContextMenuInput, bgPage = chrome.extension
-			.getBackgroundPage(), config;
+	var removeScriptsInput, removeFramesInput, removeObjectsInput, removeHiddenInput, removeUnusedCSSRulesInput,
+		processInBackgroundInput, maxFrameSizeInput, getRawDocInput, sendToPageArchiverInput, displayBannerInput,
+		displayInContextMenuInput, bgPage = chrome.extension
+			.getBackgroundPage(), config, scaleImagesInput, removeBackgroundImagesInput;
 
 	function refresh() {
 		config = bgPage.singlefile.config.get();
@@ -35,6 +37,8 @@
 		maxFrameSizeInput.value = config.maxFrameSize;
 		getRawDocInput.checked = config.getRawDoc;
 		sendToPageArchiverInput.checked = config.sendToPageArchiver;
+		scaleImagesInput.value = config.scaleImages;
+		removeBackgroundImagesInput.checked = config.removeBackgroundImages;
 		if (displayBannerInput.checked)
 			processInBackgroundInput.checked = processInBackgroundInput.disabled = true;
 	}
@@ -52,7 +56,10 @@
 			processInBackground : processInBackgroundInput.checked,
 			maxFrameSize: maxFrameSizeInput.valueAsNumber || 0,
 			getRawDoc : getRawDocInput.checked,
-			sendToPageArchiver : sendToPageArchiverInput.checked
+			sendToPageArchiver : sendToPageArchiverInput.checked,
+			scaleImages : scaleImagesInput.valueAsNumber < 0 || scaleImagesInput.valueAsNumber > 1 ? 0.2 :
+				scaleImagesInput.valueAsNumber,
+			removeBackgroundImages : removeBackgroundImagesInput.checked
 		});
 	}
 
@@ -72,6 +79,8 @@
 	maxFrameSizeInput = document.getElementById("maxFrameSizeInput");
 	getRawDocInput = document.getElementById("getRawDocInput");
 	sendToPageArchiverInput = document.getElementById("sendToPageArchiverInput");
+	scaleImagesInput = document.getElementById("scaleImages");
+	removeBackgroundImagesInput = document.getElementById("removeBackgroundImages");
 	displayInContextMenuInput.addEventListener("click", bgPage.singlefile.refreshMenu);
 	displayBannerInput.addEventListener("click", updateProcessInBackground, false);
 	document.getElementById("resetButton").addEventListener("click", function() {


### PR DESCRIPTION
The output .htm files can be quite big (10+MB) due to the embedded images. I added an option in Options to compress and scale down images to the size they are displayed in. The compression level is changeable by the user.

I also added an option to remove background image from the output, as often this would be the reason for a huge .htm output file.

Last I added a few comments to help with following the flow of the code, which proved quite difficult when I was first getting into it.

Note 1: I might be porting this to Firefox soon. I already have a Version that work on Firefox, but it is heavily modified, based on crossrider and still Buggy. I however, figured out all the incompatibilities in the JavaScript between this and Firefox's dialect and can rewrite the pieces in a way that is processable by both Browsers.
A question for you - will you be accepting changes geared towards Firefox compatibility or shall I work in a different repo, shall I decide to make a production Version out of what I have?

Note 2: You might be interested to know that I created an Extension (just entering Testphase) that includes a modified Version of your SingleFile (https://github.com/jimmytaker/SmartCollector.git). I do not know whether I want this yet, but I will consider it, if you are on board with the idea - extracting the SingleFile Core functionality from SmartCollector, adding SingleFile Core as a requirement (in the same way your Extension works) and adding the changes necessary for SmartCollector to SingleFile Core. Currently These are
1: the ability to produce a SingleFile AND an HTM with just the Images extracted from it and stored next to it as separate files.
2. Processing of native files (e.g. when you have a .pdf or .jpg opened in the browser)
