### PR TITLE
Support pages missing HEAD in the DOM

### DIFF
--- a/lib/single-file/util/doc-helper.js
+++ b/lib/single-file/util/doc-helper.js
@@ -58,7 +58,7 @@ this.docHelper = this.docHelper || (() => {
 			disabledNoscriptElement.hidden = true;
 			element.parentElement.replaceChild(disabledNoscriptElement, element);
 		});
-		doc.head.querySelectorAll("*:not(base):not(link):not(meta):not(noscript):not(script):not(style):not(template):not(title)").forEach(element => element.hidden = true);
+		doc.head && doc.head.querySelectorAll("*:not(base):not(link):not(meta):not(noscript):not(script):not(style):not(template):not(title)").forEach(element => element.hidden = true);
 		let canvasData, imageData, usedFonts, shadowRootContents;
 		if (win) {
 			canvasData = getCanvasData(doc, win);
@@ -203,7 +203,7 @@ this.docHelper = this.docHelper || (() => {
 			Array.from(element.childNodes).forEach(node => noscriptElement.appendChild(node));
 			element.parentElement.replaceChild(noscriptElement, element);
 		});
-		doc.head.querySelectorAll("*:not(base):not(link):not(meta):not(noscript):not(script):not(style):not(template):not(title)").forEach(element => element.removeAttribute("hidden"));
+		doc.head && doc.head.querySelectorAll("*:not(base):not(link):not(meta):not(noscript):not(script):not(style):not(template):not(title)").forEach(element => element.removeAttribute("hidden"));
 		if (options.removeHiddenElements) {
 			doc.querySelectorAll("[" + REMOVED_CONTENT_ATTRIBUTE_NAME + "]").forEach(element => element.removeAttribute(REMOVED_CONTENT_ATTRIBUTE_NAME));
 		}


### PR DESCRIPTION
There are pages where document.head is null. Most notably, Chrome builtin PDF viewer creates such pages.
There, doc.head.querySelectorAll understandably crashes. To reproduce, visit any URL like https://arxiv.org/pdf/1901.08586.pdf
It's of course better to save renamed PDFs directly, but this at least avoids crashing :)
Note there are other places where the code might crash without document.head, these are just the obvious ones.

Also, thanks for the great extension!