### PR TITLE
Fix incognito issue in Firefox<=56

### DIFF
--- a/extension/core/bg/download.js
+++ b/extension/core/bg/download.js
@@ -57,7 +57,7 @@ singlefile.download = (() => {
 				return downloadPage(message, { confirmFilename: message.confirmFilename, incognito: sender.tab.incognito, filenameConflictAction: message.filenameConflictAction })
 					.catch(error => {
 						if (error.message) {
-							if (error.message.includes("'incognito'")) {
+							if (error.message.includes("'incognito'") || error.message.includes("\"incognito\"")) {
 								return downloadPage(message, { confirmFilename: message.confirmFilename, filenameConflictAction: message.filenameConflictAction });
 							} else if (error.message == "conflictAction prompt not yet implemented") {
 								return downloadPage(message, { confirmFilename: message.confirmFilename });


### PR DESCRIPTION
This makes it possible for SingleFile to save pages in private windows in Waterfox and Firefox version<=56 when saving in background is enabled in the extension's options (as in the default configuration). Without this fix saving fails silently.