### PR TITLE
Specify text color of controls on the options page

### DIFF
--- a/extension/ui/pages/options.css
+++ b/extension/ui/pages/options.css
@@ -29,6 +29,7 @@ input[type=text] {
     border-style: solid;
     border-radius: 2px;
     border-width: 1px;
+    color: black;
 }
 
 input[type=checkbox] {


### PR DESCRIPTION
Without this Firefox uses system colors and this may result in, for example, white text on a white background.