### PR TITLE
Fix cancelled save blocking next ones (Firefox)

### DIFF
--- a/extension/core/bg/download.js
+++ b/extension/core/bg/download.js
@@ -98,7 +98,11 @@ singlefile.download = (() => {
 					return downloadPage(page, { confirmFilename: options.confirmFilename, filenameConflictAction: options.filenameConflictAction });
 				} else if (errorMessage == "conflictaction prompt not yet implemented" && options.filenameConflictAction) {
 					return downloadPage(page, { confirmFilename: options.confirmFilename });
-				} else if (!errorMessage.includes("canceled")) {
+				} else if (errorMessage.includes("canceled")) {
+					URL.revokeObjectURL(page.url);
+					return {};
+				}
+				else {
 					throw error;
 				}
 			} else {


### PR DESCRIPTION
Description of the bug:

1. Turn on the following options:
    * File name > open the "Save as" dialog to confirm the file name
    * Misc. > save pages in background
2. Open a webpage.
3. Request saving the webpage (e.g. click the toolbar button).
4. Wait until the page is processed and a 'Save as' dialog appears.
5. Press 'Cancel' in that dialog.

Result:
Now it is impossible to save the page without reloading it. When you click the button again, the only thing that happens is that the button shows a badge with dots and a tooltip that reads 'Initializing SingleFile (2/2)'.