### PR TITLE
Continuation of memory leak fixes from #194

### DIFF
--- a/extension/core/bg/data/config.js
+++ b/extension/core/bg/data/config.js
@@ -362,15 +362,23 @@ singlefile.config = (() => {
 			filename: "singlefile-settings.json",
 			saveAs: true
 		};
+		try {
+			return await downloadConfig(downloadInfo);
+		} finally {
+			URL.revokeObjectURL(url);
+		}
+	}
+
+	async function downloadConfig(downloadInfo) {
 		let downloadId;
 		try {
 			downloadId = await browser.downloads.download(downloadInfo);
 		} catch (error) {
-			if (!error.message || !error.message.toLowerCase().includes("canceled")) {
+			if (error.message && error.message.toLowerCase().includes("canceled")) {
+				return {};
+			} else {
 				throw error;
 			}
-		} finally {
-			URL.revokeObjectURL(url);
 		}
 		return new Promise((resolve, reject) => {
 			browser.downloads.onChanged.addListener(onChanged);


### PR DESCRIPTION
Note: New PR because I failed to reopen #194.
This is an improvement of commit 5b446e35312401569cfa253700e413c5910932b2, making code more like the one from [`download.js`][download.js]. The current form has the following issues:
* `revokeObjectURL()` is called without waiting for `new Promise(...)` to complete (it might be too early),
* an `onChanged` listener is registered even when the download has been cancelled in Firefox, but in that case it is never going to be fired and unregistered (which creates another memory leak, although smaller that the original one).

[download.js]: https://github.com/gildas-lormeau/SingleFile/blob/5b446e35312401569cfa253700e413c5910932b2/extension/core/bg/download.js#L60-L69