### PR TITLE
Enable `npm install single-file --global`

### DIFF
--- a/cli/README.MD
+++ b/cli/README.MD
@@ -10,29 +10,9 @@ SingleFile can be launched from the command line by running it into a (headless)
 
 - Install [Node.js](https://nodejs.org)
 
-- Unzip the [master archive](https://github.com/gildas-lormeau/SingleFile/archive/master.zip) somewhere on your disk in an empty folder and go into the `SingleFile-master/cli` directory.
+- Install `single-file` on your system with:
 
-  `unzip master.zip .`
-  
-  `cd SingleFile-master`
-  
-  `cd cli`
-  
-- As an alternative to decompressing the master archive, you can clone the repository if `git` is installed on your machine and go into the `SingleFile/cli` directory.
-
-  `git clone https://github.com/gildas-lormeau/SingleFile.git`
-  
-  `cd SingleFile`
-  
-  `cd cli`
-
-- Install dependencies with npm (installed with Node.js).
-
-  `npm install`
-  
-- Make `single-file` executable (Linux/Unix/BSD etc.).
-
-  `chmod +x single-file`
+  `npm install single-file --global`
 
 - To use Firefox instead of Chrome, you must download the [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver) component (i.e. `geckodriver` for Firefox).  Make sure it can be found through the `PATH` environment variable or the `cli` folder. Otherwise you will need to set the `--web-driver-executable-path` option to help WebDriver locating the executable.
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,6 +4,7 @@
 	"description": "SingleFile",
 	"author": "Gildas Lormeau",
 	"license": "AGPL-3.0-or-later",
+	"bin": "./single-file",
 	"dependencies": {
 		"file-url": "*",
 		"iconv-lite": "*",


### PR DESCRIPTION
Fixes #394 

After merging this and #413, you just need to run:

```sh
cd cli
npm publish
```

and `single-file` will be available on npm