### PR TITLE
Fix bug with infobar template evaulation

### DIFF
--- a/lib/single-file/single-file-core.js
+++ b/lib/single-file/single-file-core.js
@@ -1404,7 +1404,6 @@ this.singlefile.lib.core = this.singlefile.lib.core || (() => {
 			const publisherElement = this.doc.querySelector("meta[name=publisher]");
 			const headingElement = this.doc.querySelector("h1");
 			this.options.title = titleElement ? titleElement.textContent.trim() : "";
-			this.options.infobarContent = await ProcessorHelper.evalTemplate(this.options.infobarTemplate, this.options, null, true);
 			this.options.info = {
 				description: descriptionElement && descriptionElement.content ? descriptionElement.content.trim() : "",
 				lang: this.doc.documentElement.lang,
@@ -1413,6 +1412,7 @@ this.singlefile.lib.core = this.singlefile.lib.core || (() => {
 				publisher: publisherElement && publisherElement.content ? publisherElement.content.trim() : "",
 				heading: headingElement && headingElement.textContent ? headingElement.textContent.trim() : ""
 			};
+			this.options.infobarContent = await ProcessorHelper.evalTemplate(this.options.infobarTemplate, this.options, null, true);
 		}
 	}
 


### PR DESCRIPTION
### Issue:

Infobar template evaulation is done before all the possible template variables are ready.

### Steps to reproduce:

[Verified on vanilla Google Chrome Version 85.0.4183.121 (Official Build) (64-bit) with no other plugins]

<img width="403" alt="2020_10_04_15-38-41" src="https://user-images.githubusercontent.com/172235/95018449-c01d5000-0657-11eb-8131-d84326659642.png">

1. Set "template of the infobar content" (or `infobarTemplate` in the setting JSON) to: `{page-heading}`.
2. Try to save any page

### What happens:

It gets stuck like this:

<img width="139" alt="2020_10_04_15-26-37" src="https://user-images.githubusercontent.com/172235/95018347-176ef080-0657-11eb-93b4-d81be0dace0c.png">

... with this error in the console:

<img width="628" alt="2020_10_04_15-27-12" src="https://user-images.githubusercontent.com/172235/95018352-205fc200-0657-11eb-9654-217dbec21487.png">

<hr>

This  happens because line 1407 evaluates the template (`{page-heading}`) calling `evalTemplate` which expects `this.options.info` to be set. However, this is set in line 1408.

https://github.com/gildas-lormeau/SingleFile/blob/8948efce035778676788e1236a9c78bb5bbcdc82/lib/single-file/single-file-core.js#L1407-L1414

### The fix:

Evaluate the template after `this.options.info` is set.