### PR TITLE
Fix min-height property not being removed on main window when zooming.

### DIFF
--- a/lib/single-file/single-file-core.js
+++ b/lib/single-file/single-file-core.js
@@ -1377,10 +1377,14 @@ this.singlefile.lib.core = this.singlefile.lib.core || (() => {
 			const transformPriority = this.doc.documentElement.style.getPropertyPriority("-sf-transform");
 			const transformOrigin = this.doc.documentElement.style.getPropertyValue("-sf-transform-origin");
 			const transformOriginPriority = this.doc.documentElement.style.getPropertyPriority("-sf-transform-origin");
+			const minHeight = this.doc.documentElement.style.getPropertyValue("-sf-min-height");
+			const minHeightPriority = this.doc.documentElement.style.getPropertyPriority("-sf-min-height");
 			this.doc.documentElement.style.setProperty("transform", transform, transformPriority);
 			this.doc.documentElement.style.setProperty("transform-origin", transformOrigin, transformOriginPriority);
+			this.doc.documentElement.style.setProperty("min-height", minHeight, minHeightPriority);
 			this.doc.documentElement.style.removeProperty("-sf-transform");
 			this.doc.documentElement.style.removeProperty("-sf-transform-origin");
+			this.doc.documentElement.style.removeProperty("-sf-min-height");
 		}
 
 		async insertMAFFMetaData() {


### PR DESCRIPTION
Looks like `min-height` was added recently, but just didn't get added to this `resetZoomLevel` for the top-level window.

Copied over the reset code from [https://github.com/gildas-lormeau/SingleFile/blob/master/lib/single-file/processors/hooks/content/content-hooks-frames-web.js#L191-L192](url)