### PR TITLE
New --browser-server param for CLI

### DIFF
--- a/cli/args.js
+++ b/cli/args.js
@@ -31,6 +31,7 @@ const args = require("yargs")
 	})
 	.default({
 		"back-end": "puppeteer",
+		"browser-server": "",
 		"browser-headless": true,
 		"browser-executable-path": "",
 		"browser-width": 1280,
@@ -87,6 +88,7 @@ const args = require("yargs")
 	})
 	.options("back-end", { description: "Back-end to use" })
 	.choices("back-end", ["jsdom", "puppeteer", "webdriver-chromium", "webdriver-gecko", "puppeteer-firefox", "playwright-firefox", "playwright-chromium"])
+	.options("browser-server", { description: "Server to connect to (puppeteer only for now)" })
 	.options("browser-headless", { description: "Run the browser in headless mode (puppeteer, webdriver-gecko, webdriver-chromium)" })
 	.boolean("browser-headless")
 	.options("browser-executable-path", { description: "Path to chrome/chromium executable (puppeteer, webdriver-gecko, webdriver-chromium)" })

--- a/cli/back-ends/puppeteer.js
+++ b/cli/back-ends/puppeteer.js
@@ -33,7 +33,11 @@ const NETWORK_STATES = ["networkidle0", "networkidle2", "load", "domcontentloade
 let browser;
 
 exports.initialize = async options => {
-	browser = await puppeteer.launch(getBrowserOptions(options));
+	if (options.browserServer) {
+		browser = await puppeteer.connect({ browserWSEndpoint: options.browserServer });
+	} else {
+		browser = await puppeteer.launch(getBrowserOptions(options));
+	}
 	return browser;
 };
 


### PR DESCRIPTION
Hi!

Would you be interested on something like this? I love the tool but I don't want to add Chromium to my Heroku dynos for it to work so I'm reusing browserless.io for puppeteer interactions on the project I'm working on.