### PR TITLE
Fix bad setAttribute call

### DIFF
--- a/lib/single-file/single-file-core.js
+++ b/lib/single-file/single-file-core.js
@@ -1022,7 +1022,7 @@ this.singlefile.lib.core = this.singlefile.lib.core || (() => {
 							const templateElement = doc.createElement("template");
 							templateElement.setAttribute(SHADOW_MODE_ATTRIBUTE_NAME, shadowRootData.mode);
 							if (shadowRootData.delegatesFocus) {
-								templateElement.setAttribute(SHADOW_DELEGATE_FOCUS_ATTRIBUTE_NAME);
+								templateElement.setAttribute(SHADOW_DELEGATE_FOCUS_ATTRIBUTE_NAME, "");
 							}
 							if (shadowRootData.adoptedStyleSheets) {
 								shadowRootData.adoptedStyleSheets.forEach(stylesheetContent => {


### PR DESCRIPTION
I didn't bother to check what this attribute is supposed to do or why the problem only manifested now, but this incorrect `setAttribute()` call is breaking saving with SingleFile in Zotero Connector([#366](https://github.com/zotero/zotero-connectors/issues/366)) on ScienceDirect. This PR fixes the issue.