### PR TITLE
Google Drive upload bugfix

### DIFF
--- a/extension/core/bg/autosave.js
+++ b/extension/core/bg/autosave.js
@@ -166,7 +166,7 @@ async function saveContent(message, tab) {
 				if (options.saveToGDrive) {
 					const blob = new Blob([pageData.content], { type: "text/html" });
 					await (await downloads.saveToGDrive(message.taskId, pageData.filename, blob, options, {})).uploadPromise;
-				} if (options.saveToGitHub) {
+				} else if (options.saveToGitHub) {
 					await (await downloads.saveToGitHub(message.taskId, pageData.filename, pageData.content, options.githubToken, options.githubUser, options.githubRepository, options.githubBranch)).pushPromise;
 				} else if (options.saveWithCompanion) {
 					await companion.save({


### PR DESCRIPTION
When you only want to export to Google drive, it also downloads it. This fixes the issue.
I also want to mention that It was too hard to get it working because there was no documentation how to contribute to the project. Maybe can you add that? I'm going to open an issue about this.