### PR TITLE
Fixed infinite loop caused by regex backtracking

### DIFF
--- a/lib/single-file/single-file-core.js
+++ b/lib/single-file/single-file-core.js
@@ -2293,7 +2293,7 @@ function matchImport(stylesheetContent) {
 
 function removeCssComments(stylesheetContent) {
 	try {
-		return stylesheetContent.replace(/\/\*(.|\s)*?\*\//g, "");
+		return stylesheetContent.replace(/\/\*(.|[\r\n])*?\*\//g, "");
 	} catch (error) {
 		let start, end;
 		do {


### PR DESCRIPTION
Changed regex `\s` to `[\r\n]` instead since `\s` and `.` may not be disjoint.

Saving on this [webpage](http://r2ok.s4.bizhat.com/r2ok-forum-│30752 benedic+  20   0 5435044 317680  63488 S   0.3  1.0 151:04.38 code                                                             
14.html) now works (amongst others).
