### PR TITLE
Replace GIF demo with MP4 demo video

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -22,7 +22,7 @@ SingleFile is a Web Extension (and a CLI tool) compatible with Chrome, Firefox (
  - [License](#license)
 
 ## Demo
-![](https://github.com/gildas-lormeau/SingleFile-Demos/blob/master/demo-sf.gif)
+https://user-images.githubusercontent.com/2869411/156649921-df9fdf29-c2f2-4c7b-a80e-59dfdba7686f.mp4
 
 ## Install
 SingleFile can be installed on:


### PR DESCRIPTION
Awesome project.

After reading Hacker News I noticed a lot of people weren't fond of having a GIF demo in your README as Github now supports videos as of April 17th 2021. A video showing this new change can be seen at [https://www.youtube.com/watch?v=G3Cytlicv8Y](https://www.youtube.com/watch?v=G3Cytlicv8Y)

I converted your current GIF to MP4 which reduced the file size from 16mb to 6mb.

Completely up to you if you want to continue using GIF, just figured I'd save you some work if you thought otherwise. Thanks again.