### PR TITLE
Fixing misplaced tables in README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -187,17 +187,17 @@ More info here: https://github.com/gildas-lormeau/SingleFileZ
 
 ## File format comparison
 
-| 	 | HTML (SingleFile) | HTML (SingleFileZ) | MAFF | MHTML | Webarchive
-(Safari) | HTML+folder | | --- 	 | :---: | :---: | :---: | :---: | :---: | :---:
-| | Pages are saved as a single file | ✓ 	 | ✓ 	 | ✓ | ✓ | ✓ | | | HTML and
-styles are minified | ✓ | ✓ 	 | | | 	 | | | Unused HTML and styles are removed
-from files | ✓ | ✓ 	 | | | | 	 | | Binary resources are not encoded in base 64 |
-| ✓ 	 | ✓ | | ✓ | ✓ 	 | | Files are compressed | | ✓ 	 | ✓ | | | 	 | | Files can
-be viewed without installing any extension | ✓ | ✓¹ | | ✓² | ✓³ | ✓ | | Files
-can be viewed without running JavaScript | ✓ | 	 | ✓ | ✓ | ✓ | ✓ 	 | | Files can
-be unzipped to extract resources and view pages | | ✓ 	 | ✓ | | | n/a | | Files
-contains the text of the page (plain or formatted) which can be indexed | ✓ 	 |
-✓⁴ | | ✓ | ✓ 	 | ✓ 	 |
+| 	 | HTML (SingleFile) | HTML (SingleFileZ) | MAFF | MHTML | Webarchive(Safari) | HTML+folder | 
+| --- 	 | :---: | :---: | :---: | :---: | :---: | :---:|
+| Pages are saved as a single file | ✓ 	 | ✓ 	 | ✓ | ✓ | ✓ | |
+| HTML and styles are minified | ✓ | ✓ 	 | | | 	 | |
+| Unused HTML and styles are removed from files | ✓ | ✓ 	 | | | | 	 |
+| Binary resources are not encoded in base 64 | | ✓ 	 | ✓ | | ✓ | ✓ 	 |
+| Files are compressed | | ✓ 	 | ✓ | | | 	 |
+| Files can be viewed without installing any extension | ✓ | ✓¹ | | ✓² | ✓³ | ✓ |
+| Files can be viewed without running JavaScript | ✓ | 	 | ✓ | ✓ | ✓ | ✓ 	 |
+| Files can be unzipped to extract resources and view pages | | ✓ 	 | ✓ | | | n/a |
+| Files contains the text of the page (plain or formatted) which can be indexed | ✓ 	 |✓⁴ | | ✓ | ✓ 	 | ✓ 	 |
 
 Footnotes:
 


### PR DESCRIPTION
Invalid markdown table format.
![image](https://user-images.githubusercontent.com/899449/171532818-5cfbaf07-6321-4d51-8e83-358f29181ac9.png)