### PR TITLE
Fix development rollup config

### DIFF
--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,7 +1,7 @@
 import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
 
-const PLUGINS = [resolve({ moduleDirectories: [".."] })];
+const PLUGINS = [resolve({ moduleDirectories: ["node_modules"] })];
 const EXTERNAL = ["single-file-core"];
 
 export default [{


### PR DESCRIPTION
The dev build doesn't work right now if just cloning and building this individual repo.