### PR TITLE
Add accelerators to page/extension menus

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,80 @@
 {
+	"menuSavePage": {
+		"message": "🖺 &Save page with SingleFile",
+		"description": "Menu entry: 'Save page with SingleFile'"
+	},
+	"menuEditAndSavePage": {
+		"message": "📝 &Annotate and save the page...",
+		"description": "Menu entry: 'Annotate and save the page...'"
+	},
+	"menuSaveSelection": {
+		"message": "▋ &D Save selection",
+		"description": "Menu entry: 'Save selection'"
+	},
+	"menuSaveSelectedTabs": {
+		"message": "Save selected &tabs",
+		"description": "Menu entry: 'Save selected tabs'"
+	},
+	"menuSaveUnpinnedTabs": {
+		"message": "Save &unpinned tabs",
+		"description": "Menu entry: 'Save unpinned tabs'"
+	},
+	"menuSaveAllTabs": {
+		"message": "∀ &Y Save all tabs",
+		"description": "Menu entry: 'Save all tabs'"
+	},
+	"menuSelectProfile": {
+		"message": "☰ Select the default &profile",
+		"description": "Menu entry: 'Select the default profile'"
+	},
+	"menuCreateDomainRule": {
+		"message": "☰ Select the profile of the current do&main",
+		"description": "Menu entry: 'Select the profile of the current domain'"
+	},
+	"menuAutoSave": {
+		"message": "🔄 &G Auto-save",
+		"description": "Menu entry: 'Auto-save'"
+	},
+	"menuAutoSaveDisabled": {
+		"message": "&Disabled",
+		"description": "Menu entry: 'Auto-save' > Disabled'"
+	},
+	"menuAutoSaveTab": {
+		"message": "Auto-save this &tab",
+		"description": "Menu entry: 'Auto-save' > Auto-save this tab'"
+	},
+	"menuAutoSaveUnpinnedTabs": {
+		"message": "Auto-save &unpinned tabs",
+		"description": "Menu entry: 'Auto-save' > Auto-save unpinned tabs'"
+	},
+	"menuAutoSaveAllTabs": {
+		"message": "Auto-save &all tabs",
+		"description": "Menu entry: 'Auto-save' > Auto-save all tabs'"
+	},
+	"menuBatchSaveUrls": {
+		"message": "🗐 &Batch save URLs...",
+		"description": "Menu entry: 'Batch save URLs...'"
+	},
+	"menuViewPendingSaves": {
+		"message": "&View pending saves...",
+		"description": "Menu entry: 'View pending saves...'"
+	},
+	"menuSaveSelectedLinks": {
+		"message": "🔗 Save selected &links",
+		"description": "Menu entry: 'Save selected links'"
+	},
+	"menuSaveFrame": {
+		"message": "Save &frame",
+		"description": "Menu entry: 'Save frame'"
+	},
+	"menuSaveWithProfile": {
+		"message": "☰ Save page with p&rofile",
+		"description": "Menu entry: 'Save with profile'"
+	},
+	"profileDefaultSettings": {
+		"message": "&Default settings",
+		"description": "Label 'Default settings' of the default settings in the options page"
+	},
 	"extensionDescription": {
 		"message": "Save a complete page into a single HTML file",
 		"description": "Description of the extension."
@@ -11,89 +87,17 @@
 		"message": "Save all tabs",
 		"description": "Command (Ctrl+Shift+U): 'Save all tabs'"
 	},
-	"menuSavePage": {
-		"message": "Save page with SingleFile",
-		"description": "Menu entry: 'Save page with SingleFile'"
-	},
-	"menuSaveSelectedLinks": {
-		"message": "Save selected links",
-		"description": "Menu entry: 'Save selected links'"
-	},
 	"menuEditPage": {
 		"message": "Annotate the page...",
 		"description": "Menu entry: 'Annotate the page...'"
-	},
-	"menuEditAndSavePage": {
-		"message": "Annotate and save the page...",
-		"description": "Menu entry: 'Annotate and save the page...'"
-	},
-	"menuSaveWithProfile": {
-		"message": "Save page with profile",
-		"description": "Menu entry: 'Save with profile'"
-	},
-	"menuViewPendingSaves": {
-		"message": "View pending saves...",
-		"description": "Menu entry: 'View pending saves...'"
-	},
-	"menuSelectProfile": {
-		"message": "Select the default profile",
-		"description": "Menu entry: 'Select the default profile'"
 	},
 	"menuUpdateRule": {
 		"message": "Select the profile of the current rule",
 		"description": "Menu entry: 'Select the profile of the current rule'"
 	},
-	"menuCreateDomainRule": {
-		"message": "Select the profile of the current domain",
-		"description": "Menu entry: 'Select the profile of the current domain'"
-	},
-	"menuSaveSelection": {
-		"message": "Save selection",
-		"description": "Menu entry: 'Save selection'"
-	},
-	"menuSaveFrame": {
-		"message": "Save frame",
-		"description": "Menu entry: 'Save frame'"
-	},
 	"menuSaveTabs": {
 		"message": "Save tabs",
 		"description": "Menu entry (SingleFile button only): 'Save tabs'"
-	},
-	"menuSaveSelectedTabs": {
-		"message": "Save selected tabs",
-		"description": "Menu entry: 'Save selected tabs'"
-	},
-	"menuSaveUnpinnedTabs": {
-		"message": "Save unpinned tabs",
-		"description": "Menu entry: 'Save unpinned tabs'"
-	},
-	"menuSaveAllTabs": {
-		"message": "Save all tabs",
-		"description": "Menu entry: 'Save all tabs'"
-	},
-	"menuBatchSaveUrls": {
-		"message": "Batch save URLs...",
-		"description": "Menu entry: 'Batch save URLs...'"
-	},
-	"menuAutoSave": {
-		"message": "Auto-save",
-		"description": "Menu entry: 'Auto-save'"
-	},
-	"menuAutoSaveDisabled": {
-		"message": "Disabled",
-		"description": "Menu entry: 'Auto-save' > Disabled'"
-	},
-	"menuAutoSaveTab": {
-		"message": "Auto-save this tab",
-		"description": "Menu entry: 'Auto-save' > Auto-save this tab'"
-	},
-	"menuAutoSaveUnpinnedTabs": {
-		"message": "Auto-save unpinned tabs",
-		"description": "Menu entry: 'Auto-save' > Auto-save unpinned tabs'"
-	},
-	"menuAutoSaveAllTabs": {
-		"message": "Auto-save all tabs",
-		"description": "Menu entry: 'Auto-save' > Auto-save all tabs'"
 	},
 	"buttonDefaultTooltip": {
 		"message": "Save page with SingleFile",
@@ -774,10 +778,6 @@
 	"topPanelShareSelectionButton": {
 		"message": "Share selection...",
 		"description": "Top panel button 'Share selection...' when sharing selected content"
-	},
-	"profileDefaultSettings": {
-		"message": "Default settings",
-		"description": "Label 'Default settings' of the default settings in the options page"
 	},
 	"profileDisabled": {
 		"message": "Disabled",

--- a/src/ui/pages/help.html
+++ b/src/ui/pages/help.html
@@ -103,6 +103,9 @@
 							URL. See the description of the <a href="#auto-settings-rules">Auto-settings rules</a>
 							feature for more info. </p>
 					</li>
+					<li>
+						<p>Tip: add &amp;ampersand before a letter in the name of a profile to have faster access to it via keyboard accelerators</p>
+					</li>
 				</ul>
 				<p>User interface</p>
 				<ul>


### PR DESCRIPTION
Also added a few icons for much faster visual differentiation between the options 
- 📝 Annotate and save the page
- Annotate and save the page

By the way, do you know how to force those text icons to be in place of actual icons in the menus (there is a dedicated column for them left of text, this would solve the misalignment issue)?

I'd gone with the tradition of adding accelerators to the matching letters within the name if found, but honestly I'd just move all of them to the left just like for `&D Save selection"` since it's (to me) more important to see the shortcut right away, and those tiny underscores in the middle of sentences aren't very functional even if looking nicer

Another downside is that the extension menu has those ugly `&` marks not removed in some browsers (not in Chrome, though), and even with them the accelerators seem to work, but that's on browsers

I'd also rename the extension to `&SingleFile` just for this :) but that's maybe going too far, will just do it locally (though would be nice to find a way to somehow make it user configurable not to do ugly local patches)

(moved items around to match the menu order to make keeping track of the shortcuts/edits easier)



Partially addresses https://github.com/gildas-lormeau/SingleFile/issues/1420