### PR TITLE
2x small typo they->there

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -929,7 +929,7 @@
 	},
 	"pendingsNoPendings": {
 		"message": "No pending saves",
-		"description": "Label displayed when they are no pending saves"
+		"description": "Label displayed when there are no pending saves"
 	},
 	"pendingsAddUrlsButton": {
 		"message": "Add URLs",
@@ -953,7 +953,7 @@
 	},
 	"batchSaveUrlsNoURLs": {
 		"message": "No URLs",
-		"description": "Label displayed when they are no URLs"
+		"description": "Label displayed when there are no URLs"
 	},
 	"batchSaveUrlsAddUrlButton": {
 		"message": "Add URL",


### PR DESCRIPTION
small typo where "they" was written when "there" was meant