### PR TITLE
Fix incorrect Accept header on rest-form-api

### DIFF
--- a/src/lib/rest-form-api/index.js
+++ b/src/lib/rest-form-api/index.js
@@ -28,7 +28,7 @@
 const AUTHORIZATION_HEADER = "Authorization";
 const BEARER_PREFIX_AUTHORIZATION = "Bearer ";
 const ACCEPT_HEADER = "Accept";
-const CONTENT_TYPE = "multipart/form-data";
+const CONTENT_TYPE = "application/json";
 
 export { RestFormApi };
 


### PR DESCRIPTION
The application expects a json response, it also doesn't make sense to expect the server to reply in `multipart/form-data` as that's not a valid response type. I guess the intent was to set the request header `Content-Type` but that's automatically set by fetch due to the body type.