### PR TITLE
fix non-ASCII filename mangling caused by NBSP in page titles

### DIFF
--- a/src/core/bg/download-util.js
+++ b/src/core/bg/download-util.js
@@ -76,6 +76,20 @@ async function download(downloadInfo, replacementCharacter) {
 			} else if (invalidFilename && downloadInfo.filename.match(/\u200C|\u200D|\u200E|\u200F/)) {
 				downloadInfo.filename = downloadInfo.filename.replace(/\u200C|\u200D|\u200E|\u200F/g, replacementCharacter);
 				return download(downloadInfo, replacementCharacter);
+			} else if (invalidFilename && downloadInfo.filename.match(/[\u00A0\u202F\u00AD\u200B\uFEFF\u2060]/)) {
+				// Both Gecko and Chromium reject certain invisible codepoints in filenames via
+				// downloads.download (soft hyphen U+00AD, ZWSP U+200B, BOM U+FEFF, word joiner
+				// U+2060). Gecko additionally rejects NBSP U+00A0 and narrow NBSP U+202F, which
+				// Chromium accepts. All are valid on every modern filesystem.
+				// Russian/French/Czech/Polish typography routinely puts NBSP after one-letter
+				// prepositions, so well-typeset pages hit this constantly.
+				// Replace targeted: space-like → regular space, invisible markers → empty string.
+				// This runs BEFORE the legacy "strip all non-ASCII" branch so legitimate Cyrillic /
+				// CJK / em-dash / fullwidth colons survive.
+				downloadInfo.filename = downloadInfo.filename
+					.replace(/[\u00A0\u202F]/g, " ")
+					.replace(/[\u00AD\u200B\uFEFF\u2060]/g, "");
+				return download(downloadInfo, replacementCharacter);
 			} else if (invalidFilename && !downloadInfo.filename.match(/^[\x00-\x7F]+$/)) { // eslint-disable-line  no-control-regex
 				downloadInfo.filename = downloadInfo.filename.replace(/[^\x00-\x7F]+/g, replacementCharacter); // eslint-disable-line  no-control-regex
 				return download(downloadInfo, replacementCharacter);


### PR DESCRIPTION
Firefox's browser.downloads.download() rejects filenames containing NBSP (U+00A0) and narrow NBSP (U+202F) with "illegal characters", even though both are valid on every modern filesystem and accepted by Chromium (see https://bugzilla.mozilla.org/show_bug.cgi?id=2030811).

The existing catch-block in download-util.js had a fallback that replaced ALL non-ASCII runs with the replacement character on any "illegal characters" error — so a single invisible NBSP from typographic markup would silently destroy the entire Cyrillic/CJK/ Arabic filename.

Add a targeted retry branch (before the legacy non-ASCII strip) that handles six specific codepoints rejected by browser engines:
- U+00A0 NBSP, U+202F narrow NBSP → replaced with regular space
- U+00AD soft hyphen, U+200B ZWSP, U+FEFF BOM, U+2060 word joiner → removed

The first two are Gecko-specific rejections; the other four are rejected by both Gecko and Chromium. On Chromium the new branch never fires (no error is thrown), so behavior is unchanged.

Minimal repro (save via SingleFile on Firefox):

  <title>Pies w&nbsp;łóżku</title>

Before: "Pies w_ku (...).html" (ł ó ż eaten by non-ASCII strip)
After:  "Pies w łóżku (...).html" (NBSP → space, Polish letters intact)